### PR TITLE
Cleanup and update for React 0.14.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Start counting on render
 
 ```js
 import React from 'react';
+import ReactDOM from 'react-dom';
 import ReactInterval from 'react-interval';
 
 const App = React.createClass({
@@ -66,7 +67,7 @@ const App = React.createClass({
 });
 
 
-React.render(<App />, document.body);
+ReactDOM.render(<App />, appRoot);
 ```
 
 ### Full example
@@ -74,6 +75,7 @@ Chang timeout on the fly, start and stop counting
 
 ```js
 import React from 'react';
+import ReactDOM from 'react-dom';
 import ReactInterval from 'react-interval';
 
 const App = React.createClass({
@@ -112,7 +114,7 @@ const App = React.createClass({
 });
 
 
-React.render(<App />, document.body);
+ReactDOM.render(<App />, appRoot);
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Start counting on render
 
 ```js
 import React from 'react';
-import ReactDOM from 'react-dom';
 import ReactInterval from 'react-interval';
 
 const App = React.createClass({
@@ -65,9 +64,6 @@ const App = React.createClass({
     );
   }
 });
-
-
-ReactDOM.render(<App />, appRoot);
 ```
 
 ### Full example
@@ -75,7 +71,6 @@ Chang timeout on the fly, start and stop counting
 
 ```js
 import React from 'react';
-import ReactDOM from 'react-dom';
 import ReactInterval from 'react-interval';
 
 const App = React.createClass({
@@ -112,9 +107,6 @@ const App = React.createClass({
     );
   }
 });
-
-
-ReactDOM.render(<App />, appRoot);
 ```
 
 ## Options

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "homepage": "https://github.com/nkbt/react-interval",
   "dependencies": {
-    "react": "^0.13.3"
+    "react": "^0.13 || ^0.14"
   },
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "parallelshell": "^2.0.0",
     "phantomjs": "^1.9.18",
     "react": "^0.14.0",
+    "react-addons-pure-render-mixin": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-hot-loader": "^1.3.0",
     "rimraf": "^2.4.3",

--- a/src/ReactInterval.js
+++ b/src/ReactInterval.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
+import {shouldComponentUpdate} from 'react-addons-pure-render-mixin';
 
 
 const ReactInterval = React.createClass({


### PR DESCRIPTION
- Exclusively depend on ^0.14.0 of react
- Use react-addons-pure-render-mixin instead of an internal require that'll likely be deprecated
- In example and README examples:
  - Use render from react-dom instead of the deprecated one in react
  - Don't render directly into document.body, this causes a React warning

This should be a new breaking release.
